### PR TITLE
Fix go to declaration on Windows

### DIFF
--- a/lib/parsing/compiler.js
+++ b/lib/parsing/compiler.js
@@ -5,7 +5,7 @@ var   state = require('../haxe-state')
     , path = require('path')
 
     // Match haxe compiler output info
-var REGEX_HAXE_COMPILER_OUTPUT_LINE = /^\s*([^\:]+)\:([0-9]+)\:\s+(characters|lines)\s+([0-9]+)\-([0-9]+)(?:\s+\:\s*(.*?))?\s*$/;
+var REGEX_HAXE_COMPILER_OUTPUT_LINE = /^\s*(.+)?(?=\:[0-9]*\:)\:([0-9]+)\:\s+(characters|lines)\s+([0-9]+)\-([0-9]+)(?:\s+\:\s*(.*?))?\s*$/;
 
 module.exports = {
 


### PR DESCRIPTION
The previous regex don't match with Windows style path and the go to feature wasn't working.
This one ensures that the path is captured until :line_number:
