### PR TITLE
Add arguments type in suggestions

### DIFF
--- a/lib/completion/provider.js
+++ b/lib/completion/provider.js
@@ -641,6 +641,10 @@ module.exports = {
                             arg_str = '?' + arg_str;
                         }
 
+                        if (arg.type) {
+                            arg_str += ':' + code.string_from_parsed_type(arg.type);
+                        }
+
                         number_of_chars += arg_str.length + 2;
                         if (number_of_chars > 40) {
                             arg_str = arg_str.slice(0, arg_str.length - number_of_chars + 42);


### PR DESCRIPTION
Added arguments type to the completation hint.

This shows simple types, function signatures and generics:
![sample](http://i.imgur.com/0onXHZ8.png)
