### PR TITLE
Don't decrease indent for "case" and "default"

### DIFF
--- a/settings/haxe.cson
+++ b/settings/haxe.cson
@@ -4,4 +4,4 @@
     'commentEnd': ''
     'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
     'increaseIndentPattern': '(?x)\n\t\t(\n\t\t\t\\{ [^}"\']*\n\t\t|\t\\( [^)"\']*\n\t\t|\tcase[\\s\\S]*:\n\t\t|\tdefault:\n\t\t)\n\t\t$\n\t'
-    'decreaseIndentPattern': '^(.*\\*/)?\\s*(\\}|\\)|case|default)'
+    'decreaseIndentPattern': '^(.*\\*/)?\\s*(\\}|\\))'


### PR DESCRIPTION
It is causing unwanted indent decrease for "inline cases" (i.e. `case cond: expr;` in the same line)
