### PR TITLE
Info on easier way to install atom packages w/o using the interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ this can be configured in the settings, but is not usually required.
 
 **Required Atom Packages**
 
-Install these from atom Settings -> Install
+Install these either from Atom -> Settings -> Install, or run `apm install [package-name]` on your CLI if you have atom shell commands installed.
 
 - requires `linter` package
 - requires `language-haxe` package


### PR DESCRIPTION
Addresses issue #65. Until automatic dependency gets functioning, info about how to use `apm` shell command could be useful since its a mess to find the package you are searching for using the Packages UI of Atom.